### PR TITLE
change plugin name to wepublish

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ or
 Import and initialise the tracker anywhere in the project
 
     import  Analytics  from  'analytics'
-    import { matomoPlugin } from '@wepublish/analytics'
+    import { wepublish } from '@wepublish/analytics'
     
     const  analytics = Analytics({
 	    app: 'Your app name',
-	    plugins: [matomoPlugin()]
+	    plugins: [wepublish()]
     })
 
 then call the method on page load e.g.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,6 +1,6 @@
-declare const matomoPlugin: () => {
+declare const wepublish: () => {
     name: string;
     page: () => void;
     track: (params: any) => void;
 };
-export { matomoPlugin };
+export { wepublish };

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.matomoPlugin = void 0;
+exports.wepublish = void 0;
 const matomo_tracker_1 = require("@jonkoops/matomo-tracker");
 const matomo = new matomo_tracker_1.default({
     siteId: 1,
@@ -10,9 +10,9 @@ let pageInterval;
 let pageTimeout;
 let trackInterval;
 let trackTimeout;
-const matomoPlugin = () => {
+const wepublish = () => {
     return {
-        name: "wp-matomo-analytics",
+        name: "wp-analytics",
         page: () => {
             if (pageInterval) {
                 clearInterval(pageInterval);
@@ -79,4 +79,4 @@ const matomoPlugin = () => {
         },
     };
 };
-exports.matomoPlugin = matomoPlugin;
+exports.wepublish = wepublish;

--- a/index.ts
+++ b/index.ts
@@ -10,9 +10,9 @@ let pageTimeout: number;
 let trackInterval: number;
 let trackTimeout: number;
 
-const matomoPlugin = () => {
+const wepublish = () => {
   return {
-    name: "wp-matomo-analytics",
+    name: "wp-analytics",
     page: () => {
       if (pageInterval) {
         clearInterval(pageInterval);
@@ -94,4 +94,4 @@ const matomoPlugin = () => {
   };
 };
 
-export { matomoPlugin };
+export { wepublish };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wepublish/analytics",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Analytics plugin for publishers.",
   "license": "MIT",
   "repository": "wepublish/analytics",


### PR DESCRIPTION
@tomaszdurka suggested to change the name of the plugin to just wepublish to not expose the details of our implementation